### PR TITLE
feat: Add VLC player support with fallback to QMediaPlayer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+PyQt5
+requests
+packaging
+python-vlc


### PR DESCRIPTION

Fixes #This change integrates the VLC media player for playback, with the original QMediaPlayer as a fallback.

- Adds a check for a local VLC installation on startup.
- If VLC is available, it is used as the primary player to support a wider range of media formats.
- If VLC is not available, the application seamlessly falls back to QMediaPlayer.
- Player control functions (play, stop, volume) have been updated to manage both potential players.
- Adds a `requirements.txt` file to document project dependencies, including the new `python-vlc` library.